### PR TITLE
:heavy_plus_sign: chore: Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "url": "https://github.com/l2700l/reterm/issues"
   },
   "homepage": "https://github.com/l2700l/reterm#readme",
+  "dependencies": {
+    "react-device-detect": "^2.2.3"
+  },
   "devDependencies": {
     "@types/react": "^18.0.35",
     "copyfiles": "^2.4.1",


### PR DESCRIPTION
"react-device-detect" added as a dependency

"react-device-detect" package added to dependencies field in package.json

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Now when installing the package "ReTerm" will also install the package "react-device-detect"

Issue Number: N/A

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
